### PR TITLE
Enable reverse vertical option

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func main() {
 	flag.IntVar(&ncolumns, "l", 1, "number of columns")
 	flag.Float64Var(&rinterval, "i", 1.0, "rate of intervals")
 	flag.BoolVar(&reverseH, "r", false, "reverse holizontal")
+	flag.BoolVar(&reverseV, "rv", false, "reverse vertical")
 	flag.StringVar(&filename, "o", "", "output image file")
 	flag.Parse()
 


### PR DESCRIPTION
```
$ ./longcat -h
Usage of ./longcat:
  -i float
    	rate of intervals (default 1)
  -l int
    	number of columns (default 1)
  -n int
    	how long cat (default 1)
  -o string
    	output image file
  -r	reverse holizontal
  -rv
    	reverse vertical
```

<img width="564" alt="_Users_ikawaha_go_src_github_com_mattn_longcat" src="https://user-images.githubusercontent.com/4232165/64597549-f0f96a00-d3f0-11e9-8593-0e99429402e5.png">
