### PR TITLE
Fix the size of the universe

### DIFF
--- a/main.go
+++ b/main.go
@@ -70,7 +70,8 @@ func main() {
 		img3 = imaging.FlipH(img3)
 	}
 
-	rect := image.Rect(0, 0, img1.Bounds().Dx()*ncolumns, img1.Bounds().Dy()+img2.Bounds().Dy()*nlong+img3.Bounds().Dy())
+	width := int(float64(img1.Bounds().Dx()*(ncolumns-1))*rinterval) + img1.Bounds().Dx()
+	rect := image.Rect(0, 0, width, img1.Bounds().Dy()+img2.Bounds().Dy()*nlong+img3.Bounds().Dy())
 	canvas := image.NewRGBA(rect)
 
 	for col := 0; col < ncolumns; col++ {


### PR DESCRIPTION
## Before

![omg02_s](https://user-images.githubusercontent.com/20859/64738236-a92a2e00-d529-11e9-9a9a-5f781a07b396.png)

```shell
$ go run main.go -o ../omg00.png
$ go run main.go -l 20 -n 5 -o ../omg01.png
$ go run main.go -i 0.2 -l 20 -n 5 -o ../omg02.png
$ magick identify ../omg*.png
..\omg00.png PNG 150x241 150x241+0+0 8-bit sRGB 25006B 0.000u 0:00.000
..\omg01.png PNG 3000x401 3000x401+0+0 8-bit sRGB 68529B 0.000u 0:00.000
..\omg02.png PNG 3000x401 3000x401+0+0 8-bit sRGB 57523B 0.000u 0:00.000
```

TODO: Insert O.M.G. cat image here.

> ..\omg02.png PNG **3000x401** 3000x401+0+0 8-bit sRGB 57523B 0.000u 0:00.000

## After

![new_omg02_s](https://user-images.githubusercontent.com/20859/64738242-ae877880-d529-11e9-8a5a-92dc71eabd61.png)

```shell
$ go run main.go -o ../new_omg00.png
$ go run main.go -l 20 -n 5 -o ../new_omg01.png
$ go run main.go -i 0.2 -l 20 -n 5 -o ../new_omg02.png
$ magick identify ../new_omg*.png
..\new_omg00.png PNG 150x241 150x241+0+0 8-bit sRGB 25006B 0.000u 0:00.000
..\new_omg01.png PNG 3000x401 3000x401+0+0 8-bit sRGB 68529B 0.000u 0:00.000
..\new_omg02.png PNG 720x401 720x401+0+0 8-bit sRGB 50511B 0.000u 0:00.000
```

Looks good.

> ..\new_omg02.png PNG **720x401** 720x401+0+0 8-bit sRGB 50511B 0.000u 0:00.000