### PR TITLE
Support iTerm2 Inline Images Protocol (fixes #3)

### DIFF
--- a/iterm/iterm.go
+++ b/iterm/iterm.go
@@ -1,0 +1,46 @@
+package iterm
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+)
+
+// Encoder encode image to sixel format
+type Encoder struct {
+	w      io.Writer
+	Width  int
+	Height int
+}
+
+// NewEncoder return new instance of Encoder
+func NewEncoder(w io.Writer) *Encoder {
+	return &Encoder{w: w}
+}
+
+func (e *Encoder) Encode(img image.Image) error {
+	width, height := img.Bounds().Dx(), img.Bounds().Dy()
+	if e.Width != 0 {
+		width = e.Width
+	}
+	if e.Height != 0 {
+		height = e.Height
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		return err
+	}
+
+	fmt.Print("\033]1337;")
+	fmt.Printf("File=inline=1")
+	fmt.Printf(";width=%dpx", width)
+	fmt.Printf(";height=%dpx", height)
+	fmt.Print(":")
+	fmt.Printf("%s", base64.StdEncoding.EncodeToString(buf.Bytes()))
+	fmt.Print("\a\n")
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -14,9 +14,11 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/disintegration/imaging"
 	"github.com/mattn/go-sixel"
+	"github.com/mattn/longcat/iterm"
 	_ "github.com/mattn/longcat/statik"
 	"github.com/rakyll/statik/fs"
 )
@@ -100,8 +102,13 @@ func main() {
 	}
 
 	var buf bytes.Buffer
-	err = sixel.NewEncoder(&buf).Encode(output)
-	if err != nil {
+	var enc interface{ Encode(image.Image) error }
+	if strings.HasPrefix(os.Getenv("TERM_PROGRAM"), "iTerm") {
+		enc = iterm.NewEncoder(&buf)
+	} else {
+		enc = sixel.NewEncoder(&buf)
+	}
+	if err := enc.Encode(output); err != nil {
 		log.Fatal(err)
 	}
 	os.Stdout.Write(buf.Bytes())


### PR DESCRIPTION
Fixes #3

Reference:
- https://www.iterm2.com/documentation-images.html
- https://github.com/olivere/iterm2-imagetools/blob/master/cmd/imgcat/imgcat.go
