### PR TITLE
Validate a name of theme 

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,24 @@ func loadImageGlob(dir string, glob string) (image.Image, error) {
 }
 
 func (t *Theme) loadTheme(themeName string) error {
+	contains := func(ss []string, target string) bool {
+		for _, s := range ss {
+			if s == target {
+				return true
+			}
+		}
+		return false
+	}
+
+	// The theme exists?
+	themeNames, err := getThemeNames()
+	if err != nil {
+		return err
+	}
+	if !contains(themeNames, themeName) {
+		return fmt.Errorf("theme does not exist: %s", themeName)
+	}
+
 	fs, err := fs.New()
 	if err != nil {
 		return err
@@ -111,6 +129,32 @@ func saveImage(filename string, img image.Image) error {
 		return err
 	}
 	return ioutil.WriteFile(filename, buf.Bytes(), 0644)
+}
+
+func getThemeNames() ([]string, error) {
+	fs, err := fs.New()
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := fs.Open("/themes")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	// List "/themes/*" directory in statik
+	infos, err := f.Readdir(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, len(infos))
+	for i, v := range infos {
+		names[i] = v.Name()
+	}
+
+	return names, nil
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -157,6 +157,18 @@ func getThemeNames() ([]string, error) {
 	return names, nil
 }
 
+func printThemeNames() error {
+	names, err := getThemeNames()
+	if err != nil {
+		return err
+	}
+
+	for _, v := range names {
+		fmt.Println(v)
+	}
+	return nil
+}
+
 func main() {
 	var nlong int
 	var ncolumns int
@@ -167,6 +179,7 @@ func main() {
 	var filename string
 	var imageDir string
 	var themeName string
+	var listsThemes bool
 
 	flag.IntVar(&nlong, "n", 1, "how long cat")
 	flag.IntVar(&ncolumns, "l", 1, "number of columns")
@@ -177,7 +190,16 @@ func main() {
 	flag.StringVar(&filename, "o", "", "output image file")
 	flag.StringVar(&imageDir, "d", "", "directory of images(dir/*{1,2,3}.png)")
 	flag.StringVar(&themeName, "t", "longcat", "name of theme")
+	flag.BoolVar(&listsThemes, "themes", false, "list themes")
+
 	flag.Parse()
+
+	if listsThemes {
+		if err := printThemeNames(); err != nil {
+			log.Fatal(err)
+		}
+		return
+	}
 
 	theme := Theme{}
 	if imageDir == "" {


### PR DESCRIPTION
## Motivation
 
If the theme does not exist,  the longcat causes panic.
This is not easy-to-understand for humankind.

![2019-09-17_bjj6l-longcat-error](https://user-images.githubusercontent.com/20859/65088680-29063b80-d9f5-11e9-9e08-ef7716736da0.png)

* Add validation of theme name
* Add `-themes` option to list themes
 
ref.  Supporting theme mattn/longcat#12

## Before 

```shell
$ go run main.go -n 2 -H -t wlongcat
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x████████]

goroutine 1 [running]:
main.main()
        ████████████████████████████████████████████longcat/main.go:151 +0x4d5
exit status 2
```

## After

```shell
$ go run main.go -n 2 -H -t wlongcat
████████ ████ theme does not exist: wlongcat
exit status 1

$ go run main.go -themes
longcat
tacgnol
```
