### PR TITLE
Prevent iTerm2 from displaying broken_image.png instead of long cats

### DIFF
--- a/iterm/iterm.go
+++ b/iterm/iterm.go
@@ -7,6 +7,8 @@ import (
 	"image"
 	"image/png"
 	"io"
+
+	"github.com/disintegration/imaging"
 )
 
 // Encoder encode image to sixel format
@@ -23,6 +25,17 @@ func NewEncoder(w io.Writer) *Encoder {
 
 func (e *Encoder) Encode(img image.Image) error {
 	width, height := img.Bounds().Dx(), img.Bounds().Dy()
+	maxDimension := 9999 // kMaxDimension-1 in iTerm2/sources/iTermImage.m
+	if width > maxDimension || height > maxDimension {
+		if width > height {
+			height = height * maxDimension / width
+			width = maxDimension
+		} else {
+			width = width * maxDimension / height
+			height = maxDimension
+		}
+		img = imaging.Resize(img, width, height, imaging.Lanczos)
+	}
 	if e.Width != 0 {
 		width = e.Width
 	}


### PR DESCRIPTION
On iTerm2, longcat -n 190 shows a longcat, but longcat -n 191 shows broken_image.png instead of a pretty longcat.

![スクリーンショット 2019-09-27 22 57 15](https://user-images.githubusercontent.com/107537/65918107-d1fc5f80-e413-11e9-9f58-b33f213d63d2.png)

Because iTerm2 processes an image with size smaller than

```
static const CGFloat kMaxDimension = 10000;
```
in https://github.com/gnachman/iTerm2/blob/master/sources/iTermImage.m.
(iTerm2 debug log says "iTermImage.m:276 (-[iTermImage initWithJson:]): Bogus size {126, 10033}")

This is a workaround for it by resizing image not to exceed the threshold.

Regards,