### PR TITLE
Avoid crash with invalid integer flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -251,6 +251,16 @@ func main() {
 
 	flag.Parse()
 
+	if nlong < 1 {
+		log.SetFlags(0)
+		log.Fatalf("invalid value \"%v\" for flag -n", nlong)
+	}
+	
+	if ncolumns < 1 {
+		log.SetFlags(0)
+		log.Fatalf("invalid value \"%v\" for flag -l", ncolumns)
+	}
+	
 	if listsThemes {
 		if err := printThemeNames(); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
Since flag.IntVar accepts negative value, it may cause crash on subsequent processing.

e.g. on mlterm
![negative-n-on-mlterm](https://user-images.githubusercontent.com/107537/66398583-ff02d080-ea18-11e9-8438-921f2d7a4df2.png)
