### PR TITLE
Return nil if image size is zero on iTerm2

### DIFF
--- a/iterm/iterm.go
+++ b/iterm/iterm.go
@@ -25,6 +25,9 @@ func NewEncoder(w io.Writer) *Encoder {
 
 func (e *Encoder) Encode(img image.Image) error {
 	width, height := img.Bounds().Dx(), img.Bounds().Dy()
+	if width == 0 || height == 0 {
+		return nil
+	}
 	maxDimension := 9999 // kMaxDimension-1 in iTerm2/sources/iTermImage.m
 	if width > maxDimension || height > maxDimension {
 		if width > height {


### PR DESCRIPTION
On iTerm2, size 0 image is passed to the png encoder and cause error in it:
```
$ ./longcat -H  -l 0
2019/10/12 09:44:18 png: invalid format: invalid image size: 0x0
```
By returning first as with other backends, avoiding Encoder error.
