### PR TITLE
Support macOS's Terminal.app

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/mattn/pixterm v1.2.5-0.20191008162044-72ff621ffbff
 	github.com/rakyll/statik v0.1.7
 	github.com/soniakeys/quant v1.0.0 // indirect
+	github.com/tomnomnom/xtermcolor v0.0.0-20160428124646-b78803f00a7e
 	github.com/zyxar/image2ascii v0.0.0-20180912034614-460a04e371ae
 	golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
 	golang.org/x/image v0.0.0-20200119044424-58c23975cae1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/soniakeys/quant v1.0.0 h1:N1um9ktjbkZVcywBVAAYpZYSHxEfJGzshHCxx/DaI0Y
 github.com/soniakeys/quant v1.0.0/go.mod h1:HI1k023QuVbD4H8i9YdfZP2munIHU4QpjsImz6Y6zds=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/tomnomnom/xtermcolor v0.0.0-20160428124646-b78803f00a7e h1:Ee+VZw13r9NTOMnwTPs6O5KZ0MJU54hsxu9FpZ4pQ10=
+github.com/tomnomnom/xtermcolor v0.0.0-20160428124646-b78803f00a7e/go.mod h1:fSIW/szJHsRts/4U8wlMPhs+YqJC+7NYR+Qqb1uJVpA=
 github.com/zyxar/image2ascii v0.0.0-20180912034614-460a04e371ae h1:EiqxsQwk1eimsz+ncJrsMMMwnkYTGiVOrLe5lGxL9cs=
 github.com/zyxar/image2ascii v0.0.0-20180912034614-460a04e371ae/go.mod h1:Md4Hcw0pmYWDCo1o/fHeOC2Gdhc6oDRwLim8V+SMvI0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/main.go
+++ b/main.go
@@ -185,6 +185,10 @@ func checkIterm() bool {
 	return strings.HasPrefix(os.Getenv("TERM_PROGRAM"), "iTerm")
 }
 
+func checkTerminalApp() bool {
+	return os.Getenv("TERM_PROGRAM") == "Apple_Terminal"
+}
+
 func checkSixel() bool {
 	if isatty.IsCygwinTerminal(os.Stdout.Fd()) {
 		return true
@@ -246,6 +250,7 @@ func main() {
 	var imageDir string
 	var themeName string
 	var isPixterm bool
+	var is8BitColor bool
 	var listsThemes bool
 	var darkMode bool
 	var asciiMode bool
@@ -260,6 +265,7 @@ func main() {
 	flag.StringVar(&imageDir, "d", "", "directory of images(dir/*{1,2,3}.png)")
 	flag.StringVar(&themeName, "t", "longcat", "name of theme")
 	flag.BoolVar(&isPixterm, "pixterm", false, "pixterm mode")
+	flag.BoolVar(&is8BitColor, "8", false, "8bit color")
 	flag.BoolVar(&listsThemes, "themes", false, "list themes")
 	flag.BoolVar(&darkMode, "dark", false, "dark-mode(a.k.a. tacgnol theme)")
 	flag.BoolVar(&asciiMode, "ascii", false, "ascii mode")
@@ -361,7 +367,8 @@ func main() {
 	}
 
 	if isPixterm {
-		enc = pixterm.NewEncoder(&buf)
+		is8BitColor = checkTerminalApp()
+		enc = pixterm.NewEncoder(&buf, is8BitColor)
 	}
 
 	if asciiMode {


### PR DESCRIPTION
# Problem

macOS's Terminal.app doesn't support true color and longcat -pixterm shows broken cat:

![Terminal app-before](https://user-images.githubusercontent.com/107537/87214440-847c2e00-c367-11ea-847b-9207971f65eb.png)

# Fix

Terminal.app sets the environment variable TERM_PROGRAM to "Apple_Terminal".
Use 8bit (256) color escape sequence in such case.

![Terminal app-after](https://user-images.githubusercontent.com/107537/87214449-9d84df00-c367-11ea-8fc3-c97dbef4b34f.png)

# Limitation

If the user force to use same logic on iTerm2 (alternative for macOS bundled Terminal.app) with Solarized theme shows a slightly broken cat:

![iTerm2-256color](https://user-images.githubusercontent.com/107537/87214558-a6c27b80-c368-11ea-8843-9f6f09534b29.png)

I think this is caused by the theme changes color palette. The Default behavior on iTerm2 is kept intact on this fix.