### PR TITLE
Ignore tw if its value is invalid

### DIFF
--- a/pixterm/pixterm.go
+++ b/pixterm/pixterm.go
@@ -58,7 +58,7 @@ func (e *Encoder) Encode(img image.Image) error {
 		return nil
 	}
 	tw, _, err := terminal.GetSize(int(os.Stdout.Fd()))
-	if err == nil && width > tw*ansimage.BlockSizeX {
+	if err == nil && tw > 0 && width > tw*ansimage.BlockSizeX {
 		width = tw * ansimage.BlockSizeX
 	}
 	if e.Width != 0 {


### PR DESCRIPTION
terminal.GetSize(1) returns tw = 0 sometimes and it fails to write image with the error:
ANSImage: height or width must be >=2

The behaviour is observed with docker image built/run on Chrome OS (Chromebook C101PA-OP1) :
Linux penguin 5.4.40-04224-g891a6cce2d44 mattn#1 SMP PREEMPT Tue Jun 23 20:13:49 PDT 2020 aarch64 GNU/Linux