### PR TITLE
Resize images larger than the maximum size that kitty can handle

### DIFF
--- a/iterm/iterm.go
+++ b/iterm/iterm.go
@@ -31,10 +31,10 @@ func (e *Encoder) Encode(img image.Image) error {
 	maxDimension := 9999 // kMaxDimension-1 in iTerm2/sources/iTermImage.m
 	if width > maxDimension || height > maxDimension {
 		if width > height {
-			height = height * maxDimension / width
 			width = maxDimension
+			height = 0 // preserve aspect ratio
 		} else {
-			width = width * maxDimension / height
+			width = 0 // preserve aspect ratio
 			height = maxDimension
 		}
 		img = imaging.Resize(img, width, height, imaging.Lanczos)

--- a/kitty/kitty.go
+++ b/kitty/kitty.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"math"
 	"strings"
+
+	"github.com/disintegration/imaging"
 )
 
 // Encoder encode image to sixel format
@@ -27,6 +29,17 @@ func (e *Encoder) Encode(img image.Image) error {
 	width, height := img.Bounds().Dx(), img.Bounds().Dy()
 	if width == 0 || height == 0 {
 		return nil
+	}
+	max_size := 10000
+	if width > max_size || height > max_size {
+		if width > height {
+			height = height * max_size / width
+			width = max_size
+		} else {
+			width = width * max_size / height
+			height = max_size
+		}
+		img = imaging.Resize(img, width, height, imaging.Lanczos)
 	}
 	if e.Width != 0 {
 		width = e.Width

--- a/kitty/kitty.go
+++ b/kitty/kitty.go
@@ -33,10 +33,10 @@ func (e *Encoder) Encode(img image.Image) error {
 	max_size := 10000
 	if width > max_size || height > max_size {
 		if width > height {
-			height = height * max_size / width
 			width = max_size
+			height = 0 // preserve aspect ratio
 		} else {
-			width = width * max_size / height
+			width = 0 // preserve aspect ratio
 			height = max_size
 		}
 		img = imaging.Resize(img, width, height, imaging.Lanczos)


### PR DESCRIPTION
There is a limit to the image size that kitty can handle.
The maximum size is 10000:
https://github.com/kovidgoyal/kitty/blob/c7eb63d4ff9fda4e294eea3933bd7a424c70f723/kitty/graphics.c#L327

So, `longcat -n N` with N >= 191 fails to display the image.
This patch resize larger image as we do in iterm/iterm.go, and make the image be displayed.

Regards,