### PR TITLE
Use 8 bit color on tty.js (xterm mode)

### DIFF
--- a/main.go
+++ b/main.go
@@ -224,11 +224,21 @@ func checkKitty() bool {
 	return strings.HasPrefix(getDA2(), "\x1b[>1;4000;") // \x1b[>1;{major+4000};{minor}c
 }
 
-func checkTerminalApp() bool {
-	if os.Getenv("TERM_PROGRAM") == "Apple_Terminal" {
+func check8BitColor() bool {
+	if os.Getenv("TERM_PROGRAM") == "Apple_Terminal" { // Terminal.app
 		return true
 	}
-	return getDA2() == "\x1b[>1;95;0c" // Terminal.app
+	da2 := getDA2()
+	var supportedTerminals = []string{
+		"\x1b[>1;95;0c",  // Terminal.app
+		"\x1b[>0;276;0c", // tty.js (xterm mode)
+	}
+	for _, supportedTerminal := range supportedTerminals {
+		if da2 == supportedTerminal {
+			return true
+		}
+	}
+	return false
 }
 
 func checkSixel() bool {
@@ -420,7 +430,7 @@ func main() {
 	}
 
 	if isPixterm {
-		is8BitColor = is8BitColor || checkTerminalApp()
+		is8BitColor = is8BitColor || check8BitColor()
 		enc = pixterm.NewEncoder(&buf, is8BitColor)
 	}
 


### PR DESCRIPTION
This will allow AWS CloudShell to represent the correct colors.

# before

![スクリーンショット 2020-12-29 20 22 15](https://user-images.githubusercontent.com/107537/103280453-cda66400-4a13-11eb-92de-d0eb1252774d.png)

(we can use -8 option to get correct colors)

# after

![スクリーンショット 2020-12-29 20 22 55](https://user-images.githubusercontent.com/107537/103280475-db5be980-4a13-11eb-951d-46b39fdbe6ff.png)
