### PR TITLE
Replace deprecated ioutil with os

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,6 @@ import (
 	"image/draw"
 	"image/png"
 	"io/fs"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -64,7 +63,7 @@ func loadImageGlob(dir string, glob string) (image.Image, error) {
 		return nil, fmt.Errorf("file does not exist: %s", pattern)
 	}
 
-	data, err := ioutil.ReadFile(matches[0])
+	data, err := os.ReadFile(matches[0])
 	if err != nil {
 		return nil, err
 	}
@@ -140,7 +139,7 @@ func saveImage(filename string, img image.Image) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(filename, buf.Bytes(), 0644)
+	return os.WriteFile(filename, buf.Bytes(), 0644)
 }
 
 func getThemeNames() ([]string, error) {

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -17,7 +16,7 @@ func TestThemeImages(t *testing.T) {
 		t.Fatal("themes file is not found : ", err)
 	}
 
-	themedirs, err := ioutil.ReadDir(themeDir)
+	themedirs, err := os.ReadDir(themeDir)
 	if err != nil {
 		t.Fatal("themes file is not found : ", err)
 	}
@@ -25,7 +24,7 @@ func TestThemeImages(t *testing.T) {
 	for _, themedir := range themedirs {
 		if themedir.IsDir() {
 			t.Log("found theme : ", themedir.Name())
-			files, err := ioutil.ReadDir(themeDir + "/" + themedir.Name())
+			files, err := os.ReadDir(themeDir + "/" + themedir.Name())
 			if err != nil {
 				t.Log("theme image is not found. skipping,,, : ", err)
 				continue


### PR DESCRIPTION
`ioutil` has been deprecated in Go 1.16. The same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os).

I replaced deprecated `ioutil` with package `os`.