### PR TITLE
Use Kitty graphics protocol on ghostty

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,6 +201,9 @@ func checkKitty() bool {
 	if os.Getenv("KITTY_WINDOW_ID") != "" {
 		return true
 	}
+	if os.Getenv("TERM_PROGRAM") == "ghostty" {
+		return true
+	}
 	return strings.HasPrefix(getDA2(), "\x1b[>1;4000;") // \x1b[>1;{major+4000};{minor}c
 }
 


### PR DESCRIPTION
Ghostty supports Kitty image protocol (https://ghostty.org/docs/features#feature-highlight), but doesn't support Sixel.
Before the change, DA1 response \x1b[?62;22c causes a misjudgment to use Sixel.


<img width="172" alt="image" src="https://github.com/user-attachments/assets/43bb8ab2-7a4a-4abb-97f6-8efb1bab3baa" />
