### PR TITLE
Return encoder write errors

### DIFF
--- a/extraterm/extraterm.go
+++ b/extraterm/extraterm.go
@@ -62,6 +62,6 @@ func (e *Encoder) Encode(img image.Image) error {
 		previous_hash = hash
 	}
 	builder.WriteString(fmt.Sprintf("E::%x\n\000", sha256.Sum256(previous_hash)))
-	e.w.Write([]byte(builder.String()))
-	return nil
+	_, err := e.w.Write([]byte(builder.String()))
+	return err
 }

--- a/extraterm/extraterm_test.go
+++ b/extraterm/extraterm_test.go
@@ -1,0 +1,21 @@
+package extraterm
+
+import (
+	"errors"
+	"image"
+	"testing"
+)
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestEncodeReturnsWriteError(t *testing.T) {
+	enc := NewEncoder(errWriter{})
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	if err := enc.Encode(img); err == nil {
+		t.Fatal("Encode returned nil for a writer error")
+	}
+}

--- a/iterm/iterm.go
+++ b/iterm/iterm.go
@@ -50,13 +50,15 @@ func (e *Encoder) Encode(img image.Image) error {
 		return err
 	}
 
-	fmt.Fprint(e.w, "\033]1337;")
-	fmt.Fprintf(e.w, "File=inline=1")
-	fmt.Fprintf(e.w, ";width=%dpx", width)
-	fmt.Fprintf(e.w, ";height=%dpx", height)
-	fmt.Fprint(e.w, ":")
-	fmt.Fprintf(e.w, "%s", base64.StdEncoding.EncodeToString(buf.Bytes()))
-	fmt.Fprint(e.w, "\a\n")
+	var out bytes.Buffer
+	fmt.Fprint(&out, "\033]1337;")
+	fmt.Fprintf(&out, "File=inline=1")
+	fmt.Fprintf(&out, ";width=%dpx", width)
+	fmt.Fprintf(&out, ";height=%dpx", height)
+	fmt.Fprint(&out, ":")
+	fmt.Fprintf(&out, "%s", base64.StdEncoding.EncodeToString(buf.Bytes()))
+	fmt.Fprint(&out, "\a\n")
 
-	return nil
+	_, err := e.w.Write(out.Bytes())
+	return err
 }

--- a/iterm/iterm_test.go
+++ b/iterm/iterm_test.go
@@ -1,0 +1,21 @@
+package iterm
+
+import (
+	"errors"
+	"image"
+	"testing"
+)
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestEncodeReturnsWriteError(t *testing.T) {
+	enc := NewEncoder(errWriter{})
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	if err := enc.Encode(img); err == nil {
+		t.Fatal("Encode returned nil for a writer error")
+	}
+}

--- a/kitty/kitty.go
+++ b/kitty/kitty.go
@@ -67,6 +67,6 @@ func (e *Encoder) Encode(img image.Image) error {
 			builder.WriteString(fmt.Sprintf("m=0;%s\033\\\n", b64data[i*chunk_size:]))
 		}
 	}
-	e.w.Write([]byte(builder.String()))
-	return nil
+	_, err := e.w.Write([]byte(builder.String()))
+	return err
 }

--- a/kitty/kitty_test.go
+++ b/kitty/kitty_test.go
@@ -1,0 +1,21 @@
+package kitty
+
+import (
+	"errors"
+	"image"
+	"testing"
+)
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestEncodeReturnsWriteError(t *testing.T) {
+	enc := NewEncoder(errWriter{})
+	img := image.NewRGBA(image.Rect(0, 0, 8, 8))
+	if err := enc.Encode(img); err == nil {
+		t.Fatal("Encode returned nil for a writer error")
+	}
+}

--- a/pixterm/pixterm.go
+++ b/pixterm/pixterm.go
@@ -85,6 +85,6 @@ func (e *Encoder) Encode(img image.Image) error {
 	if e.is8BitColor {
 		s = to8BitColor(s)
 	}
-	e.w.Write([]byte(s))
-	return nil
+	_, err = e.w.Write([]byte(s))
+	return err
 }

--- a/pixterm/pixterm_test.go
+++ b/pixterm/pixterm_test.go
@@ -1,0 +1,21 @@
+package pixterm
+
+import (
+	"errors"
+	"image"
+	"testing"
+)
+
+type errWriter struct{}
+
+func (errWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestEncodeReturnsWriteError(t *testing.T) {
+	enc := NewEncoder(errWriter{}, false)
+	img := image.NewRGBA(image.Rect(0, 0, 16, 16))
+	if err := enc.Encode(img); err == nil {
+		t.Fatal("Encode returned nil for a writer error")
+	}
+}


### PR DESCRIPTION
Return write errors from the iTerm, Kitty, Extraterm, and pixterm encoders so broken pipes and other output failures are reported instead of being silently treated as successful encodes.