### PR TITLE
Check stdout write errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"image/color"
 	"image/draw"
 	"image/png"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -164,6 +165,17 @@ func printThemeNames() error {
 
 	for _, v := range names {
 		fmt.Println(v)
+	}
+	return nil
+}
+
+func writeOutput(w io.Writer, data []byte) error {
+	n, err := w.Write(data)
+	if err != nil {
+		return err
+	}
+	if n != len(data) {
+		return io.ErrShortWrite
 	}
 	return nil
 }
@@ -430,10 +442,14 @@ func main() {
 		log.Fatal(err)
 	}
 
+	var err error
 	if runtime.GOOS == "windows" {
-		colorable.NewColorableStdout().Write(buf.Bytes())
+		err = writeOutput(colorable.NewColorableStdout(), buf.Bytes())
 	} else {
-		os.Stdout.Write(buf.Bytes())
+		err = writeOutput(os.Stdout, buf.Bytes())
+	}
+	if err != nil {
+		log.Fatal(err)
 	}
 	os.Stdout.Sync()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"io"
 	"os"
 	"testing"
 )
@@ -46,5 +48,29 @@ func TestThemeImages(t *testing.T) {
 			}
 
 		}
+	}
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) {
+	return len(p) - 1, nil
+}
+
+type failWriter struct{}
+
+func (failWriter) Write([]byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+func TestWriteOutput(t *testing.T) {
+	if err := writeOutput(io.Discard, []byte("longcat")); err != nil {
+		t.Fatalf("writeOutput returned unexpected error: %v", err)
+	}
+	if err := writeOutput(failWriter{}, []byte("longcat")); err == nil {
+		t.Fatal("writeOutput returned nil for a writer error")
+	}
+	if err := writeOutput(shortWriter{}, []byte("longcat")); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("writeOutput returned %v, want %v", err, io.ErrShortWrite)
 	}
 }


### PR DESCRIPTION
Check the final stdout write and report write failures or short writes instead of silently succeeding after encoding output.