### PR TITLE
Validate positive output options

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,6 +180,19 @@ func writeOutput(w io.Writer, data []byte) error {
 	return nil
 }
 
+func validateOutputOptions(nlong, ncolumns int, rinterval float64) error {
+	if nlong < 0 {
+		return fmt.Errorf("n must be greater than or equal to 0: %d", nlong)
+	}
+	if ncolumns < 1 {
+		return fmt.Errorf("l must be greater than or equal to 1: %d", ncolumns)
+	}
+	if rinterval <= 0 {
+		return fmt.Errorf("i must be greater than 0: %g", rinterval)
+	}
+	return nil
+}
+
 var bgColor = color.RGBA64{0, 0, 0, 0xFFFF}
 
 func fillBackground(img image.Image) image.Image {
@@ -343,6 +356,10 @@ func main() {
 	if darkMode {
 		themeName = "tacgnol"
 		imageDir = "" // Forcibly apply the above theme
+	}
+
+	if err := validateOutputOptions(nlong, ncolumns, rinterval); err != nil {
+		log.Fatal(err)
 	}
 
 	theme := Theme{}

--- a/main_test.go
+++ b/main_test.go
@@ -74,3 +74,28 @@ func TestWriteOutput(t *testing.T) {
 		t.Fatalf("writeOutput returned %v, want %v", err, io.ErrShortWrite)
 	}
 }
+
+func TestValidateOutputOptions(t *testing.T) {
+	tests := []struct {
+		name      string
+		nlong     int
+		ncolumns  int
+		rinterval float64
+		wantErr   bool
+	}{
+		{name: "valid", nlong: 1, ncolumns: 1, rinterval: 1},
+		{name: "zero length", nlong: 0, ncolumns: 1, rinterval: 1},
+		{name: "negative length", nlong: -1, ncolumns: 1, rinterval: 1, wantErr: true},
+		{name: "zero columns", nlong: 1, ncolumns: 0, rinterval: 1, wantErr: true},
+		{name: "zero interval", nlong: 1, ncolumns: 1, rinterval: 0, wantErr: true},
+		{name: "negative interval", nlong: 1, ncolumns: 1, rinterval: -1, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOutputOptions(tt.nlong, tt.ncolumns, tt.rinterval)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateOutputOptions() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Validate output sizing options so negative lengths, zero columns, and non-positive intervals fail fast instead of producing empty or nonsensical images.